### PR TITLE
Allow extending classes to access the resultSubject

### DIFF
--- a/library/src/main/java/com/petarmarijanovic/rxactivityresult/RxActivityResultFragment.java
+++ b/library/src/main/java/com/petarmarijanovic/rxactivityresult/RxActivityResultFragment.java
@@ -19,7 +19,7 @@ import io.reactivex.subjects.PublishSubject;
 /** Created by petar on 26/07/2017. */
 public class RxActivityResultFragment extends Fragment {
 
-  private PublishSubject<Pair<Integer, ActivityResult>> resultSubject = PublishSubject.create();
+  protected PublishSubject<Pair<Integer, ActivityResult>> resultSubject = PublishSubject.create();
 
   @Override
   public void onActivityResult(int requestCode, int resultCode, Intent data) {


### PR DESCRIPTION
I'm looking to add some custom code into a subclass of
`RxActivityResultFragment` and given the `resultSubject`
always exists, I'd like to reuse this object rather than creating
another, identical one in the subclass as that'd be wasteful.